### PR TITLE
doesn't create the database specified by -rdb

### DIFF
--- a/bin/mysql2rethink
+++ b/bin/mysql2rethink
@@ -87,6 +87,7 @@ var main = function () {
     if (err) throw err
 
     console.log("Writing to Rethink...")
+    r.dbCreate(opts.rdb)
     r.db(opts.rdb).tableCreate(opts.rtable).run(reConn, function (err) {})
     r.db(opts.rdb).table(opts.rtable).insert(results).run(reConn, function (err) {
       if (err) throw err


### PR DESCRIPTION
Now, the specified database with -rdb is created, whereas before it was assuming that the database already existed
